### PR TITLE
Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM centos:8
+MAINTAINER alex4108@live.com
+RUN dnf update -y
+RUN dnf install -y yum-utils createrepo syslinux genisoimage isomd5sum bzip2 curl file git wget unzip
+RUN curl -L -o /root/CentOS-8.1.1911-x86_64-boot.iso http://isoredirect.centos.org/centos/8/isos/x86_64/CentOS-8.1.1911-x86_64-boot.iso
+RUN echo $(sha256sum /root/CentOS-8.1.1911-x86_64-boot.iso)
+RUN curl -L -o /root/bootstrap.zip https://github.com/uboreas/centos-8-minimal/archive/ef31f862908af773c74c234353e6bbad48b1ef5e.zip
+RUN unzip /root/bootstrap.zip -d /root/
+RUN mv /root/centos-8-minimal-ef31f862908af773c74c234353e6bbad48b1ef5e/* /root/
+COPY create_iso_in_container.sh /root/
+RUN chmod +x create_iso_in_container.sh && /root/create_iso_in_conatainer.sh
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ Hence, there are two main parts of this project:
 - Script itself and template files as essentials (**bootstrap.sh** and templ\_\* files explained in Footnotes section)
 - An additional package list to install during OS installation (**packages.txt**).
 
+### Running in Docker
+
+- Requires Docker & Internet Connection
+
+  You can build the Dockerfile here and run it with a sample command.  Note that to retrieve your ISO after the container has finished creation, you must specify a mount point at `/mnt` during the container's execution in order to retrieve the file.  Additionally, privileged execution is required by the container to mount the ISO during the recreation process.
+
+  Example: `mkdir ./iso-out && docker build -t centos-8-minimal && docker run --privileged -v ./iso-out:/mnt centos-8-minimal` 
+
 ### Requirements
 
 - CentOS 8

--- a/create_iso_in_container.sh
+++ b/create_iso_in_container.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+./bootstrap.sh clean
+./bootstrap.sh step isomount
+./bootstrap.sh step createtemplate
+./bootstrap.sh step scandeps
+./bootstrap.sh step createrepo
+./bootstrap.sh step createiso
+./bootstrap.sh step isounmount
+cp ./CentOS-8.1.1911-x86_64-minimal.iso /mnt/


### PR DESCRIPTION
It's a little shoddy and only been tested with -boot ISO's but it works for creating the minimal ISO in an OS that isn't Cent8.  All you need is the centos:8 container to get the RHEL dependencies for the script to run :) 