### PR TITLE
Fix regex to remove version

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -440,7 +440,8 @@ function cmcollectrpm() {
                echo -n "."
             fi
          else
-            pk="$(echo "${r}" | awk -F".el8" {'print $1'} | sed 's/\-[0-9\.\-]\+$//g')"
+            pk="$(echo "${r}" | awk -F".el8" {'print $1'} \
+               | sed -e 's/~.*$//' -e 's/\-[0-9\.\-]\+$//g')"
             fu="$(echo "${dl}" | grep "/${r}$")"
             if [ "${fu}" == "" ]; then
                ir="$(echo "${r}" | sed 's/\.x86_64/\.i686/g')"


### PR DESCRIPTION
It's a common practice to add strings to identify commit hash and/or
build number on package releases, creating packages like:

`foo-1.0-1~fa09248sd~b203.el8.rpm`

Change the regex used to remove version and collect package name to
work with packages in this format.